### PR TITLE
Reuse a prebuilt image for the Windows build

### DIFF
--- a/.github/workflows/windows-image.yml
+++ b/.github/workflows/windows-image.yml
@@ -18,8 +18,6 @@ jobs:
     name: Publish
     timeout-minutes: 60
     runs-on: windows-2022
-    env:
-      IMAGE: ghcr.io/${{ github.repository_owner }}/fluent-package-windows-x64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Ensure availability of Docker
@@ -46,14 +44,18 @@ jobs:
       # The tag is the hash of the Dockerfile, so that the Windows workflow can
       # ask for exactly the image its own checkout describes. The Dockerfile has
       # no COPY, so nothing else in the build context can affect the result.
+      # The owner has to be lowercased because a registry rejects an image name
+      # that is not, and a GitHub account name can contain uppercase letters.
       - name: Build and push
         shell: pwsh
         env:
+          OWNER: ${{ github.repository_owner }}
           TAG: ${{ hashFiles('fluent-package/msi/Dockerfile') }}
         run: |
-          docker build --tag "${env:IMAGE}:${env:TAG}" --tag "${env:IMAGE}:latest" fluent-package/msi
+          $image = "ghcr.io/$($env:OWNER.ToLowerInvariant())/fluent-package-windows-x64"
+          docker build --tag "${image}:${env:TAG}" --tag "${image}:latest" fluent-package/msi
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          docker push "${env:IMAGE}:${env:TAG}"
+          docker push "${image}:${env:TAG}"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          docker push "${env:IMAGE}:latest"
+          docker push "${image}:latest"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/windows-image.yml
+++ b/.github/workflows/windows-image.yml
@@ -1,0 +1,59 @@
+name: Windows build image
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'fluent-package/msi/Dockerfile'
+      - '.github/workflows/windows-image.yml'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+permissions:
+  contents: read
+  packages: write
+jobs:
+  publish:
+    name: Publish
+    timeout-minutes: 60
+    runs-on: windows-2022
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/fluent-package-windows-x64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Ensure availability of Docker
+        shell: pwsh
+        run: |
+          Start-Service docker
+          1..3 | ForEach-Object {
+            try {
+              docker version
+              Write-Host "Docker is ready"
+              exit 0
+            } catch {
+              Write-Host "Waiting for Docker..."
+              Start-Sleep -Seconds 10
+            }
+          }
+      - name: Log in to GitHub Container Registry
+        shell: pwsh
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $env:TOKEN | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      # The tag is the hash of the Dockerfile, so that the Windows workflow can
+      # ask for exactly the image its own checkout describes. The Dockerfile has
+      # no COPY, so nothing else in the build context can affect the result.
+      - name: Build and push
+        shell: pwsh
+        env:
+          TAG: ${{ hashFiles('fluent-package/msi/Dockerfile') }}
+        run: |
+          docker build --tag "${env:IMAGE}:${env:TAG}" --tag "${env:IMAGE}:latest" fluent-package/msi
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          docker push "${env:IMAGE}:${env:TAG}"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          docker push "${env:IMAGE}:latest"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,8 +43,38 @@ jobs:
               Start-Sleep -Seconds 10
             }
           }
+      # Building the image from scratch costs more than 10 minutes, most of it
+      # chocolatey installing a toolchain that only changes when the Dockerfile
+      # changes. Reuse the image published by the "Windows build image"
+      # workflow. When it is not available, for example on a pull request that
+      # edits the Dockerfile, leave MSI_BUILD_IMAGE empty so that rake falls
+      # back to building the image locally.
+      - name: Log in to GitHub Container Registry
+        if: ${{ ! steps.cache-msi.outputs.cache-hit && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        shell: pwsh
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $env:TOKEN | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Pull prebuilt build image
+        id: prebuilt-image
+        if: ${{ ! steps.cache-msi.outputs.cache-hit }}
+        shell: pwsh
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/fluent-package-windows-x64
+          TAG: ${{ hashFiles('fluent-package/msi/Dockerfile') }}
+        run: |
+          docker pull "${env:IMAGE}:${env:TAG}"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::${env:IMAGE}:${env:TAG} is not available, building the image locally instead"
+            exit 0
+          }
+          "image=${env:IMAGE}:${env:TAG}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Build
         if: ${{ ! steps.cache-msi.outputs.cache-hit }}
+        env:
+          MSI_BUILD_IMAGE: ${{ steps.prebuilt-image.outputs.image }}
         run: |
           gem install serverspec
           gem install bundler:2.2.9 --no-document

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,15 +62,19 @@ jobs:
         if: ${{ ! steps.cache-msi.outputs.cache-hit }}
         shell: pwsh
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/fluent-package-windows-x64
+          # The owner has to be lowercased because a registry rejects an image
+          # name that is not, and a GitHub account name can contain uppercase
+          # letters.
+          OWNER: ${{ github.repository_owner }}
           TAG: ${{ hashFiles('fluent-package/msi/Dockerfile') }}
         run: |
-          docker pull "${env:IMAGE}:${env:TAG}"
+          $image = "ghcr.io/$($env:OWNER.ToLowerInvariant())/fluent-package-windows-x64:${env:TAG}"
+          docker pull $image
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "::warning::${env:IMAGE}:${env:TAG} is not available, building the image locally instead"
+            Write-Host "::warning::$image is not available, building the image locally instead"
             exit 0
           }
-          "image=${env:IMAGE}:${env:TAG}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "image=$image" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Build
         if: ${{ ! steps.cache-msi.outputs.cache-hit }}
         env:

--- a/fluent-package/Rakefile
+++ b/fluent-package/Rakefile
@@ -1729,6 +1729,12 @@ SET ARCH=#{arch}
     id = os
     id = "#{id}-#{architecture}" if architecture
     docker_tag = "#{@package}-#{id}"
+    # Building this image takes over 10 minutes, and almost all of it is
+    # chocolatey installing a toolchain that only changes when the Dockerfile
+    # changes. MSI_BUILD_IMAGE lets CI hand us an image that was built and
+    # pushed in advance so that we can skip "docker build" entirely.
+    prebuilt_image = ENV["MSI_BUILD_IMAGE"].to_s.strip
+    docker_tag = prebuilt_image unless prebuilt_image.empty?
     build_command_line = [
       "docker",
       "build",
@@ -1747,7 +1753,7 @@ SET ARCH=#{arch}
 
     write_env
 
-    sh(*build_command_line)
+    sh(*build_command_line) if prebuilt_image.empty?
     sh(*run_command_line)
   end
 


### PR DESCRIPTION
The Windows build spends more than 10 minutes of its 31 on "docker build", and the runner is a fresh VM every time so no layer cache survives. Almost all of that is the chocolatey step installing git, wixtoolset, 7zip, cmake, msys2 and ruby, of which "ridk install 3" alone accounts for about 5 minutes. None of it depends on anything but the Dockerfile.

Measured on the AlmaLinux-free Windows lane of run 31061357474:

  * base image pull                    3m53s
  * chocolatey bootstrap               0m21s
  * toolchain install                  7m51s
  * bundle install of the bundled gems 13m03s
  * everything else                    6m20s

Publish the build image from a new workflow that only runs when the Dockerfile changes, and let the Windows workflow pull it instead. The tag is the hash of the Dockerfile, so a checkout always asks for the image that matches the Dockerfile it has. The Dockerfile has no COPY, so nothing else in the build context can affect the result.

When the image is not available, which happens on a pull request that edits the Dockerfile and on the master push that merges it, the pull step emits a warning and leaves MSI_BUILD_IMAGE empty so that rake builds the image locally exactly as before.

The base image layers still come from mcr.microsoft.com either way, since Docker does not push Windows foreign layers to another registry, so the 3m53s pull remains.